### PR TITLE
set master key from env

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,13 +163,19 @@ All responses from the server are returned in the following format (for all LLM 
    ```
    pip install requirements.txt
    ```
-3. Set your LLM API keys
+3. (optional)Set your LiteLLM proxy master key
+   ```
+   os.environ['LITELLM_PROXY_MASTER_KEY]` = "YOUR_LITELLM_PROXY_MASTER_KEY"
+   or
+   set LITELLM_PROXY_MASTER_KEY in your .env file
+   ```
+4. Set your LLM API keys
    ```
    os.environ['OPENAI_API_KEY]` = "YOUR_API_KEY"
    or
    set OPENAI_API_KEY in your .env file
    ```
-4. Run the server:
+5. Run the server:
    ```
    python main.py
    ```

--- a/main.py
+++ b/main.py
@@ -28,7 +28,7 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
-master_key = "sk-litellm-master-key"
+master_key = os.getenv("LITELLM_PROXY_MASTER_KEY", "sk-litellm-master-key")
 user_api_keys = set(budget_manager.get_users())
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
 


### PR DESCRIPTION
Rather than using a hardcoded master key, it is preferable to retrieve sensitive values from environment variables. This allows the key to remain private while still being accessible to the application.
Improved security by avoiding embedding secrets in code.
Flexibility to change keys without redeploying code.